### PR TITLE
add support for colon (indicating division)

### DIFF
--- a/util.typ
+++ b/util.typ
@@ -137,6 +137,7 @@
       ((captures,)) => captures.first() + "*" + captures.last(),
     )
     .replace(math.dot, "*")
+    .replace(":", "/")
 
   string
 }


### PR DESCRIPTION
Sometimes divisions are represented by a colon. For example, "x : 2," which is equivalent to "x / 2." This PR adds support for this notation.