### PR TITLE
Update util.typ to fix roots where index != 2

### DIFF
--- a/util.typ
+++ b/util.typ
@@ -69,9 +69,9 @@
     } else if n.func() == math.root {
       (
         "calc.root("
-          + math-to-str(n.at("index", default: "2"), depth: depth + 1)
-          + ", "
           + math-to-str(n.radicand, depth: depth + 1)
+          + ", "
+          + math-to-str(n.at("index", default: "2"), depth: depth + 1)
           + ")"
       )
       // Fractions

--- a/util.typ
+++ b/util.typ
@@ -69,9 +69,9 @@
     } else if n.func() == math.root {
       (
         "calc.root("
-          + math-to-str(n.radicand, depth: depth + 1)
+          + math-to-str(n.at("index", default: "2"), depth: depth + 1)
           + ", "
-          + n.at("index", default: "2")
+          + math-to-str(n.radicand, depth: depth + 1)
           + ")"
       )
       // Fractions


### PR DESCRIPTION
Hi! 
First of all, congratulations for the awesome work!

When using this library i've encountered problems while parsing math equations that contain expressions of roots where the index of the operation is not the default 2 of a square root  (for example `$ x = root(3, y) $`), so after having a quick look at the code, i realised that one more recursive parse of the index part of the expression was needed to address the problem.